### PR TITLE
Fix exports and Python imports

### DIFF
--- a/src/api/data_routes.py
+++ b/src/api/data_routes.py
@@ -1,3 +1,13 @@
+"""FastAPI routes for retrieving player data."""
+
+from fastapi import APIRouter, HTTPException
+
+from ..utils import db_service as db
+
+
+router = APIRouter()
+
+
 @router.get("/players/{player_id}/stats")
 async def get_player_stats(player_id: str):
     """Get player stats for comparison"""

--- a/src/services/sleeperService.ts
+++ b/src/services/sleeperService.ts
@@ -198,3 +198,6 @@ export const calculateStandings = (teams: Team[]) => {
       return (b.points_for || 0) - (a.points_for || 0);
     });
 };
+
+// Re-export fantasy point calculator for convenience
+export { calculateFantasyPoints } from './playerAttributesService';

--- a/src/utils/db_service.py
+++ b/src/utils/db_service.py
@@ -1,3 +1,22 @@
+"""Utility helpers for database interactions."""
+
+from typing import Dict
+import os
+
+try:
+    from supabase import create_client, Client
+except Exception:  # pragma: no cover - supabase may not be installed in dev env
+    Client = None  # type: ignore
+    create_client = None
+
+SUPABASE_URL = os.getenv("SUPABASE_URL", "")
+SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
+
+supabase: Client | None = None
+if create_client and SUPABASE_URL and SUPABASE_KEY:
+    supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+
 async def fetch_player_stats(player_id: str) -> Dict:
     """Fetch player stats from database for comparison"""
     try:


### PR DESCRIPTION
## Summary
- re-export calculateFantasyPoints from sleeperService
- flesh out FastAPI route helpers
- add supabase client scaffolding for DB helper

## Testing
- `python3 -m py_compile src/api/data_routes.py src/utils/db_service.py api/main.py`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c7d08e308330a967c65d2d4e4461